### PR TITLE
Deliver CORS response headers on error responses raised by exceptions

### DIFF
--- a/lib/charcoal/cross_origin.rb
+++ b/lib/charcoal/cross_origin.rb
@@ -4,7 +4,7 @@ module Charcoal
   module CrossOrigin
     def self.included(klass)
       klass.extend(ClassMethods)
-      klass.after_filter :set_cors_headers, :if => :cors_allowed?
+      klass.around_filter :set_cors_headers_filter, :if => :cors_allowed?
     end
 
     module ClassMethods
@@ -28,6 +28,14 @@ module Charcoal
 
     def cors_allowed?
       self.class.cors_allowed?(self, params[:action])
+    end
+
+    def set_cors_headers_filter
+      yield
+      set_cors_headers
+    rescue
+      set_cors_headers
+      raise
     end
 
     def set_cors_headers

--- a/lib/charcoal/cross_origin.rb
+++ b/lib/charcoal/cross_origin.rb
@@ -32,10 +32,8 @@ module Charcoal
 
     def set_cors_headers_filter
       yield
+    ensure
       set_cors_headers
-    rescue
-      set_cors_headers
-      raise
     end
 
     def set_cors_headers

--- a/lib/charcoal/cross_origin_controller.rb
+++ b/lib/charcoal/cross_origin_controller.rb
@@ -10,7 +10,7 @@ class Charcoal::CrossOriginController < ActionController::Base
   Routing = defined?(ActionDispatch) ? ActionDispatch::Routing : ActionController::Routing
 
   allow_cors :all
-  skip_after_filter :set_cors_headers
+  skip_around_filter :set_cors_headers_filter
 
   # OPTIONS *
   def preflight


### PR DESCRIPTION
The CORS headers such as `Access-Control-Allow-Origin` are added by an `after_filter`. This works for successful responses, but can't intercept responses where an exception was raised and then rescued with `rescue_from` to render an error response.

This can be a problem for clients making CORS requests; they can get responses to successful calls, but errors can't be handled because the browser blocks access to those responses due to the missing CORS headers.

Here, we change the `after_filter` to an `around_filter` which adds the CORS headers to the response before passing on the exception.

@steved @grosser 